### PR TITLE
Add the troubleshoot item for "Calling Remote API Errors"

### DIFF
--- a/containers/beta-workflow.md
+++ b/containers/beta-workflow.md
@@ -147,6 +147,7 @@ preflight check container scan.connect.redhat.com/ospid-[PRODUCTION-project-ID]/
 ### 8. Submit Results
   
   <b>Running container policy checks against a container that passes all tests needed to submit to Red Hat:</b>
+
   <b>Note</b> for dockerconfig, you can refer to [Authenticating to Registries](https://github.com/redhat-openshift-ecosystem/openshift-preflight#authenticating-to-registries). 
  
   *Non-Red Hat Container Registry*

--- a/containers/beta-workflow.md
+++ b/containers/beta-workflow.md
@@ -147,7 +147,8 @@ preflight check container scan.connect.redhat.com/ospid-[PRODUCTION-project-ID]/
 ### 8. Submit Results
   
   <b>Running container policy checks against a container that passes all tests needed to submit to Red Hat:</b>
-  
+  <b>Note</b> for dockerconfig, you can refer to [Authenticating to Registries](https://github.com/redhat-openshift-ecosystem/openshift-preflight#authenticating-to-registries). 
+ 
   *Non-Red Hat Container Registry*
   ```
   preflight check container registry.example.org/[your-namespace]/[image-name]:[tag] \

--- a/containers/beta-workflow.md
+++ b/containers/beta-workflow.md
@@ -150,7 +150,6 @@ preflight check container scan.connect.redhat.com/ospid-[PRODUCTION-project-ID]/
 
   <b>Note</b> for dockerconfig, you can refer to [Authenticating to Registries](https://github.com/redhat-openshift-ecosystem/openshift-preflight#authenticating-to-registries). 
  
-  *Non-Red Hat Container Registry*
   ```
   preflight check container registry.example.org/[your-namespace]/[image-name]:[tag] \
   --submit \

--- a/containers/beta-workflow.md
+++ b/containers/beta-workflow.md
@@ -147,8 +147,6 @@ preflight check container scan.connect.redhat.com/ospid-[PRODUCTION-project-ID]/
 ### 8. Submit Results
   
   <b>Running container policy checks against a container that passes all tests needed to submit to Red Hat:</b>
-
-  <b>Note</b> for dockerconfig, you can refer to [Authenticating to Registries](https://github.com/redhat-openshift-ecosystem/openshift-preflight#authenticating-to-registries). 
  
   ```
   preflight check container registry.example.org/[your-namespace]/[image-name]:[tag] \

--- a/containers/troubleshooting.md
+++ b/containers/troubleshooting.md
@@ -17,7 +17,7 @@
 ### Common Issues
 * [Authorization Errors](#authorizationerrors)
 * [File Not Found Errors](#filenotfound)
-
+* [Calling Remote API Errors](#callingremoteapierrors)
 ## <a id="runasnonroot"></a>RunAsNonRoot
 The certification tooling is verifying that the USER is declared in the dockerfile and is not one of the following:
 - USER root
@@ -62,3 +62,7 @@ Possible causes:
 ## <a id="filenotfound"></a>File Not Found Errors
 Possible causes:
   - You are not specifying the full path of the docker config file: please make sure you are using the full path, not the relative path. The file should only include the credentials for the image being certified.
+
+## <a id="callingremoteapierrors"></a>Calling Remote API Errors
+Possible causes:
+  - You are using the old opsid in --certification-project-id, you could find the project id in project link  https://connect.redhat.com/projects/1234567890/overview


### PR DESCRIPTION
For some old projects, the ospid and project id are different. If the older ospid is using in the preflight test, it will cause "calling remote api errors"