### PR TITLE
Add V4.11 Note to document

### DIFF
--- a/4.9/ga/ci-pipeline.md
+++ b/4.9/ga/ci-pipeline.md
@@ -34,6 +34,8 @@
 
 ### <a id="what-you-need"></a>What you'll need before you start:
 1. An OpenShift Cluster *(recommended version 4.8 or above)*
+> Note: The CI pipeline is not presently validated to run without issues on OpenShift version 4.11. Please use a cluster running OpenShift v4.8 through V4.10 until this validation is completed.
+
 > Note: The CI Pipeline will make a Persistent Volume claim for a 5GB volume. If you are running an [OpenShift cluster on bare metal](https://docs.openshift.com/container-platform/4.9/installing/installing_bare_metal/installing-bare-metal.html), ensure you have configured [Dynamic Volume Provisioning](https://docs.openshift.com/container-platform/4.9/storage/dynamic-provisioning.html). If you do not have Dynamic Volume Provisioning configured, consider setting up a [Local Volume](https://docs.openshift.com/container-platform/4.9/storage/persistent_storage/persistent-storage-local.html). The Local Volume storage path must have the `container_file_t` SELinux label to avoid Permission Denied errors, i.e. `chcon -Rv -t container_file_t "storage_path(/.*)?"`.
 
 2. Kubeconfig file for a user with **cluster admin privileges**


### PR DESCRIPTION
As discovered in https://connect.redhat.com/support/technology-partner/#/case/03295417, running on an OpenShift v4.11 cluster has not been validated. Alex Misstear filed https://issues.redhat.com/browse/ISV-2499 to resolve this.

Thus I've added a note to the docuementation.