### PR TITLE
Fix: Add pipeline name to the oc command

### DIFF
--- a/4.9/ga/ci-pipeline.md
+++ b/4.9/ga/ci-pipeline.md
@@ -171,7 +171,7 @@ oc adm policy add-scc-to-user anyuid -z pipeline
 ```bash
 git clone https://github.com/redhat-openshift-ecosystem/operator-pipelines
 cd operator-pipelines
-oc apply -R -f ansible/roles/operator-pipeline/templates/openshift/pipelines
+oc apply -R -f ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
 oc apply -R -f ansible/roles/operator-pipeline/templates/openshift/tasks
 ```
 A subset of tasks in the pipeline requires privilege escalation which is no longer


### PR DESCRIPTION
The oc apply command used a directory path to create ci-pipeline in the cluster. The same directory was shared with multiple pipelines which meant the oc command created more than just ci pipeline.

This commit fixes the documentation for CI pipeline by specifying a path to the tekton pipeline.